### PR TITLE
Update axe-webdriverjs to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "axe-core": "^2.0.7",
-    "axe-webdriverjs": "^0.4.0",
+    "axe-webdriverjs": "^1.1.0",
     "chalk": "^1.1.3",
     "chromedriver": "2.25.1",
     "file-url": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "axe-core": "^2.0.7",
-    "axe-webdriverjs": "^1.1.0",
+    "axe-webdriverjs": "^0.5.0",
     "chalk": "^1.1.3",
     "chromedriver": "2.25.1",
     "file-url": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "phantomjs-prebuilt": "^2.1.12",
     "promise": "^7.1.1",
     "request": "^2.76.0",
-    "selenium-webdriver": "^2.53.3",
+    "selenium-webdriver": "^3.0.0",
     "then-request": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update: fixed! ~~Pending fix of this issue: https://github.com/dequelabs/axe-webdriverjs/issues/23~~

# Change Log

## 0.5.0 - 2016-12-22
### Added
- Support for axe-cli by passing in a source for axe-core version

### Changed
- Upgrade to Selenium 3, which requires Node 6
- Replace `~` with `^` in package.json to get more 
- Allow running with Selenium remotely in tests

~~Here's an open issue, please chime in if you'd like release notes in axe-webdriverjs!
https://github.com/dequelabs/axe-webdriverjs/issues/22~~ There is now a change log :)