### PR TITLE
feat(errorOnViolation) Add a way to throw a plugin error on violations

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var fileUrl = require('file-url');
 var reporter = require('./lib/reporter');
 var chalk = require('chalk');
 var request = require('then-request');
+var PluginError = require('plugin-error');
 require('chromedriver');
 
 module.exports = function (customOptions, done) {
@@ -21,7 +22,8 @@ module.exports = function (customOptions, done) {
 		saveOutputIn: '',
 		tags: null,
 		urls: [],
-		threshold: 0
+		threshold: 0,
+		errorOnViolation: false
 	};
 
 	var options = customOptions ? Object.assign(defaultOptions, customOptions) : defaultOptions;
@@ -30,6 +32,8 @@ module.exports = function (customOptions, done) {
 	chromeCapabilities.set('chromeOptions', chromeOptions);
 	var driver = new WebDriver.Builder().withCapabilities(chromeCapabilities).build();
 	driver.manage().timeouts().setScriptTimeout(500);
+
+	var violationsCount = 0;
 
 	var tagsAreDefined = (!Array.isArray(options.tags) && options.tags !== null && options.tags !== '') ||
 		(Array.isArray(options.tags) && options.tags.length > 0);
@@ -103,6 +107,12 @@ module.exports = function (customOptions, done) {
 			reporter(resultsForReporter, options.threshold);
 			driver.quit().then(function () {
 				done();
+				if (options.errorOnViolation && violationsCount > 0) {
+					throw new PluginError(
+						'gulp-axe-webdriver',
+						'Encountered ' + violationsCount + ' axe violation errors'
+					);
+				}
 			});
 		});
 	};
@@ -150,6 +160,9 @@ module.exports = function (customOptions, done) {
 						results.url = url;
 						results.timestamp = new Date().getTime();
 						results.time = results.timestamp - startTimestamp;
+						if (results.violations.length > 0) {
+							++violationsCount;
+						}
 						if (options.verbose) {
 							console.log(chalk.cyan('Analyisis finished for: ') + url);
 						}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "fs-extra": "^0.30.0",
     "fs-path": "0.0.22",
     "glob": "^7.0.6",
+    "plugin-error": "^1.0.1",
     "promise": "^7.1.1",
     "request": "^2.76.0",
     "selenium-webdriver": "^3.0.0",


### PR DESCRIPTION
Adding a way to throw an error on violation from axe. This is useful for CI environments if you want to break the build if any new violations are introduced.

I tried writing a test for it but found it super hard to detect an error being thrown correctly with assert. Any tips and I'll gladly provide one.