### PR TITLE
Upgrading axeBuilder.analyze to remove deprecated warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,7 +155,10 @@ module.exports = function (customOptions) {
 						axeBuilder.options(options.a11yCheckOptions);
 					}
 
-					return axeBuilder.analyze(function (results) {
+					return axeBuilder.analyze(err, function (results) {
+						if (err) {
+							console.log(err);
+						}
 						results.url = url;
 						results.timestamp = new Date().getTime();
 						results.time = results.timestamp - startTimestamp;

--- a/index.js
+++ b/index.js
@@ -155,7 +155,7 @@ module.exports = function (customOptions) {
 						axeBuilder.options(options.a11yCheckOptions);
 					}
 
-					return axeBuilder.analyze(err, function (results) {
+					return axeBuilder.analyze(function (err, results) {
 						if (err) {
 							console.log(err);
 						}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "axe-core": "^3.0.1",
-    "axe-webdriverjs": "^2.0.0",
+    "axe-webdriverjs": "^2.2.0",
     "chalk": "^1.1.3",
     "chromedriver": "2.41.0",
     "file-url": "^1.1.0",


### PR DESCRIPTION
Previously this deprecated warning was appearing: 

```
axe-webdriverjs deprecated Error must be handled as the first argument of axe.analyze. See: #83 node_modules/gulp-axe-webdriver/index.js:158:24
```